### PR TITLE
Check daemon first, then end the misty run

### DIFF
--- a/misty/payload/usr/local/wycomco/misty
+++ b/misty/payload/usr/local/wycomco/misty
@@ -626,11 +626,11 @@ if [[ ( -n "$macos_12" || -n "$macos_13" || -n "$macos_14" ) ]]; then
     makecatalogs "$RepoPath" | grep 'warning'
 fi
 
+check_daemon
 log_message "stdout" "Finished misty run."
 # Enter an empty line if run as launchd to StandardOutPath
 if [[ ! -t 1 ]]; then
     echo
 fi
 
-check_daemon
 exit 0


### PR DESCRIPTION
Since the script to alter the time in the launchdaemon waits for 20 seconds, we can place the function before the message that misty has finished its run