### PR TITLE
Inform user of creation of config.txt

### DIFF
--- a/misty/payload/usr/local/wycomco/misty
+++ b/misty/payload/usr/local/wycomco/misty
@@ -462,6 +462,7 @@ if [[ ! -d "$Base_Path/usr" ]]; then
 fi
 if [[ ! -f "$Base_Path/usr/config.txt" ]]; then
     cp "$Template/config.txt" "$Base_Path/usr"
+    log_message "stdout" "Config file created in $Base_Path/usr/"
     while true; do
         echo
         echo "Please enter the time when the script should start in 24 hour format (HH:MM): "


### PR DESCRIPTION
Useful if user aborts first run before setting start time of misty. Since config file exists (without start time), initial routine will not be walked through again unless the config file gets deleted.