### PR TITLE
Check for accessibility of remote repo

### DIFF
--- a/misty/payload/usr/local/wycomco/misty
+++ b/misty/payload/usr/local/wycomco/misty
@@ -82,6 +82,10 @@ check_repo() {
     if [[ "$Is_SMB" == "yes" || "$Is_SMB" == "y" || "$Is_SMB" == "Y" || "$Is_SMB" == "Yes" || "$Is_SMB" == "YES" ]]; then
         local RepoShare=$(echo "$RepoPath" | awk -F'/' '{print $3}')
         if ! mount | grep -q "/Volumes/${RepoShare}"; then
+            if ! ping -q -c2 "${RepoName}" > /dev/null 2>&1; then
+                log_message "stderr" "Error: Remote repository \"$RepoName\" not accessible, please check."
+                exit 1
+            fi
             local interval=1
             local timeout=30
             local elapsed=0


### PR DESCRIPTION
If not accessible, a local volume `/Volumes/${RepoShare}` will be created and populated. This is not intended.