### PR TITLE
Added Tahoe support, removed Ventura support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Added
 - Support for macOS Tahoe – [PR#30](https://github.com/wycomco/misty/pull/30)
 - Check for *mist-cli* version. Exit *misty* if not up to date. – [PR#29](https://github.com/wycomco/misty/pull/29)
-- Option for `--skip-signing` in `mk_misty` for testing without notarizing and signing the pkg. Appends a `b` to the version string for distinction from signed and notarized builds – [PR#31](https://github.com/wycomco/misty/pull/31)
 
 ### Removed
 - Support for macOS Ventura – [PR#30](https://github.com/wycomco/misty/pull/30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 ## Unreleased
 
 ### Added
-- Support for macOS Taho
+- Support for macOS Taho – [PR#30](https://github.com/wycomco/misty/pull/30)
 - Check for *mist-cli* version. Exit *misty* if not up to date. – [PR#29](https://github.com/wycomco/misty/pull/29)
 
 ### Removed
-- Support for macOS Ventura
+- Support for macOS Ventura – [PR#30](https://github.com/wycomco/misty/pull/30)
 
 
 ## [0.2.5](https://github.com/wycomco/misty/releases/tag/v0.2.5) – 2025-03-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## Unreleased
 
 ### Added
-- Support for macOS Taho – [PR#30](https://github.com/wycomco/misty/pull/30)
+- Support for macOS Tahoe – [PR#30](https://github.com/wycomco/misty/pull/30)
 - Check for *mist-cli* version. Exit *misty* if not up to date. – [PR#29](https://github.com/wycomco/misty/pull/29)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 ## Unreleased
 
 ### Added
-- Check for `mist-cli` version. Exit `misty` if not up to date.
+- Support for macOS Taho
+- Check for *mist-cli* version. Exit *misty* if not up to date. – [PR#29](https://github.com/wycomco/misty/pull/29)
+
+### Removed
+- Support for macOS Ventura
 
 
 ## [0.2.5](https://github.com/wycomco/misty/releases/tag/v0.2.5) – 2025-03-24

--- a/misty/payload/usr/local/wycomco/misty
+++ b/misty/payload/usr/local/wycomco/misty
@@ -668,7 +668,7 @@ if [ -n "$macos_26" ]; then
     munki_mini=6.7
     os_major="26"
     os_maxi="15.99"
-    os_mini="10.14"
+    os_mini="10.15"
     os_munki="tahoe"
     os_nice="Tahoe"
     repo_stuff

--- a/misty/payload/usr/local/wycomco/misty
+++ b/misty/payload/usr/local/wycomco/misty
@@ -576,9 +576,9 @@ echo "RepoName: $RepoName" > /dev/null
 echo "munki_path: $munki_path" > /dev/null
 echo "munki_name: $munki_name" > /dev/null
 echo "deploy_name: $deploy_name" > /dev/null
-echo "munki_catalog_13: $munki_catalog_13" > /dev/null
 echo "munki_catalog_14: $munki_catalog_14" > /dev/null
 echo "munki_catalog_15: $munki_catalog_15" > /dev/null
+echo "munki_catalog_26: $munki_catalog_26" > /dev/null
 echo "munki_category: $munki_category" > /dev/null
 echo "time_input: $time_input" > /dev/null
 echo "localization: $localization" > /dev/null
@@ -619,17 +619,25 @@ fi
 ################################################################################
 
 # We want to check each major version seperately
+mist list installer --compatible --latest "macOS Tahoe" | grep GB > "$LogPath/tmp_state_26.txt"
 mist list installer --compatible --latest "macOS Sequoia" | grep GB > "$LogPath/tmp_state_15.txt"
 mist list installer --compatible --latest "macOS Sonoma" | grep GB > "$LogPath/tmp_state_14.txt"
-mist list installer --compatible --latest "macOS Ventura" | grep GB > "$LogPath/tmp_state_13.txt"
 
 # Remove color codes resulting from grep and clean up
+rm_color_codes "$LogPath/tmp_state_26.txt" > "$LogPath/current_state_26.txt"
 rm_color_codes "$LogPath/tmp_state_15.txt" > "$LogPath/current_state_15.txt"
 rm_color_codes "$LogPath/tmp_state_14.txt" > "$LogPath/current_state_14.txt"
-rm_color_codes "$LogPath/tmp_state_13.txt" > "$LogPath/current_state_13.txt"
 /bin/rm -f "$LogPath/tmp_state_*.txt"
 
 # Compare the content with the previous state if present, ignoring last two columns (date and compatibliity)
+if [ -f "$LogPath/previous_state_26.txt" ]; then
+    if ! awk '{ for(i=2;i<=NF-4;i++) printf "%s ", $i; print "" }' "$LogPath/current_state_26.txt" | cmp -s - <(awk '{ for(i=2;i<=NF-4;i++) printf "%s ", $i; print "" }' "$LogPath/previous_state_26.txt"); then
+        macos_26=$(extract_macos_version Tahoe "$LogPath/current_state_26.txt")
+    fi
+else
+    macos_26=$(extract_macos_version Tahoe "$LogPath/current_state_26.txt")
+fi
+
 if [ -f "$LogPath/previous_state_15.txt" ]; then
     if ! awk '{ for(i=2;i<=NF-4;i++) printf "%s ", $i; print "" }' "$LogPath/current_state_15.txt" | cmp -s - <(awk '{ for(i=2;i<=NF-4;i++) printf "%s ", $i; print "" }' "$LogPath/previous_state_15.txt"); then
         macos_15=$(extract_macos_version Sequoia "$LogPath/current_state_15.txt")
@@ -646,14 +654,6 @@ else
     macos_14=$(extract_macos_version Sonoma "$LogPath/current_state_14.txt")
 fi
 
-if [ -f "$LogPath/previous_state_13.txt" ]; then
-    if ! awk '{ for(i=2;i<=NF-4;i++) printf "%s ", $i; print "" }' "$LogPath/current_state_13.txt" | cmp -s - <(awk '{ for(i=2;i<=NF-4;i++) printf "%s ", $i; print "" }' "$LogPath/previous_state_13.txt"); then
-        macos_13=$(extract_macos_version Ventura "$LogPath/current_state_13.txt")
-    fi
-else
-    macos_13=$(extract_macos_version Ventura "$LogPath/current_state_13.txt")
-fi
-
 # Clean up tmp files
 rm -rf "$LogPath/tmp_state_*.txt"
 
@@ -662,6 +662,17 @@ rm -rf "$LogPath/tmp_state_*.txt"
 ################################################################################
 
 # Execute loops only if version has changed
+if [ -n "$macos_26" ]; then
+    fqos=$macos_26
+    munki_catalog=$munki_catalog_26
+    munki_mini=6.7
+    os_major="26"
+    os_maxi="15.99"
+    os_mini="10.14"
+    os_munki="tahoe"
+    os_nice="Tahoe"
+    repo_stuff
+fi
 if [ -n "$macos_15" ]; then
     fqos=$macos_15
     munki_catalog=$munki_catalog_15
@@ -684,24 +695,13 @@ if [ -n "$macos_14" ]; then
     os_nice="Sonoma"
     repo_stuff
 fi
-if [ -n "$macos_13" ]; then
-    fqos=$macos_13
-    munki_catalog=$munki_catalog_13
-    munki_mini=6.3
-    os_major="13"
-    os_maxi="12.99"
-    os_mini="10.12"
-    os_munki="ventura"
-    os_nice="Ventura"
-    repo_stuff
-fi
 
 ################################################################################
 # Postinstall, makecatalogs                                                    #
 ################################################################################
 
 # Only proceed if any new package(s) were created
-if [[ ( -n "$macos_13" || -n "$macos_14" || -n "$macos_15" ) ]]; then
+if [[ ( -n "$macos_14" || -n "$macos_15" || -n "$macos_26" ) ]]; then
     # Ensure correct permissions in full misty path
     munki_path="${munki_path%/}" # Remove trailing slash if present
     IFS="/" read -A subdirs <<< "$munki_path" # Split munki_path into its components (subdirectories)

--- a/misty/payload/var/root/misty/skel/config.txt
+++ b/misty/payload/var/root/misty/skel/config.txt
@@ -12,9 +12,9 @@ munki_name="macos"
 # munki name used for provisioning scenarios
 deploy_name="deploy_macos"
 # Please specify the munki catalog(s) for the respective versions
-munki_catalog_13="testing"
 munki_catalog_14="testing"
 munki_catalog_15="testing"
+munki_catalog_26="testing"
 # Please specify the munki category
 munki_category="Utilities"
 # If turned to "yes", localizations will be used. If not present yet, copy the files starting with "localized_" from the skel/ dir into the usr/ folder and adjust to your needs

--- a/misty/scripts/postinstall
+++ b/misty/scripts/postinstall
@@ -16,7 +16,7 @@ if [[ -f "$config_file" ]]; then
 munki_catalog_26="testing"
 ' "$config_file"
     echo "Added 'munki_catalog_26=\"testing\"' line after 'munki_catalog_15' in $config_file by installer." >> "$log_file"
-    sudo -u "$currentUser" osascript -e 'tell app "System Events" to display dialog "Added munki_catalog_26=\"testing\" line after munki_catalog_15 in $config_file by installer."'
+    sudo -u "$currentUser" osascript -e 'tell app "System Events" to display dialog "Added »munki_catalog_26=\"testing\"« line after »munki_catalog_15« in $config_file by installer." with title "misty Installer" buttons {"Got it"} default button "Got it"'
   fi
 fi
 

--- a/misty/scripts/postinstall
+++ b/misty/scripts/postinstall
@@ -6,17 +6,17 @@ log_file="/var/log/misty.log"
 
 # Check if config file already exists
 if [[ -f "$config_file" ]]; then
-  if grep -q '^munki_catalog_12="' "$config_file"; then
-    sed -i '' '/^munki_catalog_12="/d' "$config_file"
-    echo "Removed 'munki_catalog_12' line in $config_file by installer." >> "$log_file"
+  if grep -q '^munki_catalog_13="' "$config_file"; then
+    sed -i '' '/^munki_catalog_13="/d' "$config_file"
+    echo "Removed 'munki_catalog_13' line in $config_file by installer." >> "$log_file"
   fi
-  if ! grep -q '^munki_catalog_15="' "$config_file"; then
-    # Add the 'munki_catalog_15="testing"' line after any line that starts with 'munki_catalog_14="'
-    sed -i '' '/^munki_catalog_14="/a\
-munki_catalog_15="testing"
+  if ! grep -q '^munki_catalog_26="' "$config_file"; then
+    # Add the 'munki_catalog_26="testing"' line after any line that starts with 'munki_catalog_15="'
+    sed -i '' '/^munki_catalog_15="/a\
+munki_catalog_26="testing"
 ' "$config_file"
-    echo "Added 'munki_catalog_15=\"testing\"' line after 'munki_catalog_14' in $config_file by installer." >> "$log_file"
-    sudo -u "$currentUser" osascript -e 'tell app "System Events" to display dialog "Added munki_catalog_15=\"testing\" line after munki_catalog_14 in $config_file by installer."'
+    echo "Added 'munki_catalog_26=\"testing\"' line after 'munki_catalog_15' in $config_file by installer." >> "$log_file"
+    sudo -u "$currentUser" osascript -e 'tell app "System Events" to display dialog "Added munki_catalog_26=\"testing\" line after munki_catalog_15 in $config_file by installer."'
   fi
 fi
 


### PR DESCRIPTION
Since macOS Ventura is no longer supported by Apple, we have removed the appropriate routines and re-used them for macOS Tahoe support.