### PR TITLE
Add '--skip-signing' option and and a 'b' suffix to pkg name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 - Check for `mist-cli` version. Exit `misty` if not up to date.
+- Option for `--skip-signing` in `mk_misty` for testing without notarizing and signing the pkg. Appends a `b` to the version string for distinction from signed and notarized builds – [PR#31](https://github.com/wycomco/misty/pull/31)
 
 
 ## [0.2.5](https://github.com/wycomco/misty/releases/tag/v0.2.5) – 2025-03-24

--- a/mk_misty
+++ b/mk_misty
@@ -5,6 +5,11 @@
 REPO_URL="https://github.com/wycomco/misty.git"
 TMP_DIR="/var/tmp/misty_pkgbuild"
 ORIGINAL_DIR=$(pwd)
+MUNKIPKG_OPTIONS=""
+
+if [[ "$1" == "--skip-signing" ]]; then
+  MUNKIPKG_OPTIONS="--skip-signing"
+fi
 
 if [ -d "$TMP_DIR" ]; then
   echo "Found previously cloned repo in $TMP_DIR, deleting ..."
@@ -22,12 +27,12 @@ cd "$TMP_DIR" || { echo "Failed to cd into $TMP_DIR"; exit 1; }
 VERSION=$(git describe --tags --abbrev=0)
 echo "Current version of misty is $VERSION"
 echo "Replacing version in build-info.plist..."
-sed -E -i '' "s/[0-9]+.[0-9]+.[0-9]+/${VERSION}/g" misty/build-info.plist
+sed -E -i '' "s/[0-9]+.[0-9]+.[0-9]+/${VERSION}b/g" misty/build-info.plist
 
-munkipkg misty
+munkipkg "$MUNKIPKG_OPTIONS" misty
 munkipkg_success="$?"
 echo "Resetting version in build-info.plist..."
-sed -E -i '' "s/${VERSION}/0.0.0/g" misty/build-info.plist
+sed -E -i '' "s/${VERSION}b/0.0.0/g" misty/build-info.plist
 
 if [ "$munkipkg_success" -ne 0 ]; then
   echo "munkipkg failed."
@@ -39,4 +44,3 @@ open misty/build
 cd "$ORIGINAL_DIR"
 
 exit 0
-

--- a/mk_misty
+++ b/mk_misty
@@ -6,9 +6,11 @@ REPO_URL="https://github.com/wycomco/misty.git"
 TMP_DIR="/var/tmp/misty_pkgbuild"
 ORIGINAL_DIR=$(pwd)
 MUNKIPKG_OPTIONS=""
+SUFFIX=""
 
 if [[ "$1" == "--skip-signing" ]]; then
   MUNKIPKG_OPTIONS="--skip-signing"
+  SUFFIX="b"
 fi
 
 if [ -d "$TMP_DIR" ]; then
@@ -27,12 +29,12 @@ cd "$TMP_DIR" || { echo "Failed to cd into $TMP_DIR"; exit 1; }
 VERSION=$(git describe --tags --abbrev=0)
 echo "Current version of misty is $VERSION"
 echo "Replacing version in build-info.plist..."
-sed -E -i '' "s/[0-9]+.[0-9]+.[0-9]+/${VERSION}b/g" misty/build-info.plist
+sed -E -i '' "s/[0-9]+.[0-9]+.[0-9]+/${VERSION}${SUFFIX}/g" misty/build-info.plist
 
 munkipkg "$MUNKIPKG_OPTIONS" misty
 munkipkg_success="$?"
 echo "Resetting version in build-info.plist..."
-sed -E -i '' "s/${VERSION}b/0.0.0/g" misty/build-info.plist
+sed -E -i '' "s/${VERSION}${SUFFIX}/0.0.0/g" misty/build-info.plist
 
 if [ "$munkipkg_success" -ne 0 ]; then
   echo "munkipkg failed."


### PR DESCRIPTION
Adds the possibility of using `munkipkg`'s `--skip-signing` option for testing purposes. Skips notarization, too.

The last published version will be taken and a `b` will be appended to the version string to differentiate from possibly existing signed and notarized builds.

Usage: `mk_misty --skip-signing` to skip signing and notarization or `mk_misty` for the previous workflow doing both.